### PR TITLE
Add Blast to list of applications using Bleve

### DIFF
--- a/docs/Applications-using-bleve/index.html
+++ b/docs/Applications-using-bleve/index.html
@@ -328,7 +328,15 @@
 <li><a href="https://github.com/ekanite/ekanite">https://github.com/ekanite/ekanite</a></li>
 </ul>
 
-	</div>
+<h2 id="blast:640b2c4c13c05d4abaa6d9659bc2b04d">Blast</h2>
+
+<p>Blast is a search and indexing server built on Bleve. Makes it easy to bring up high-availability cluster with Raft consensus algorithm.</p>
+
+<ul>
+    <li><a href="https://github.com/mosuka/blast">https://github.com/mosuka/blast</a></li>
+</ul>
+
+    </div>
 </div>
 
 


### PR DESCRIPTION
I'm working on develop search server built on Bleve. I'd be grateful if you could put it on this page.
https://blevesearch.com/docs/Applications-using-bleve/