### PR TITLE
docs/Index-Mapping: Make reference to the actual interface path

### DIFF
--- a/docs/Index-Mapping/index.html
+++ b/docs/Index-Mapping/index.html
@@ -279,7 +279,7 @@
 <p>How does bleve know what type a document is?</p>
 
 <ol>
-<li>If your object implements the interface <code>bleve.Classifier</code> then bleve will use string returned by its <code>Type()</code> method.</li>
+<li>If your object implements the interface <code>bleve/mapping.Classifier</code> then bleve will use string returned by its <code>Type()</code> method.</li>
 <li>The IndexMapping has a setting called <code>TypeField</code>.  You can set this to any document path, and if the value at that path is a string, that value will be used as the typed field.  If you did not customize this setting the default is set to &ldquo;_type&rdquo;.</li>
 <li>If no type can be determined from 1 or 2, the type is set to the IndexMapping&rsquo;s <code>DefaultType</code>.  If you did not customize this setting the default is set to &ldquo;_default&rdquo;.</li>
 </ol>


### PR DESCRIPTION
While reading the docs it was hard to find the 'Classifier' as I was searching it inside
the root directory as you have here documented. It's not actually there so this
updates the path to the actual one.

I was also thinking on adding the link to the code (https://github.com/blevesearch/bleve/blob/ae28975038cb25655da968e3f043210749ba382b/mapping/mapping.go#L28) for easy finding, or even adding a bit more on the docs when it mentions the `Type()` to be like `Type() string`, but nevertheless if it has to implement an interface it may (does not) have more methods to fulfill.

Also IDK if you accept PRs or this is generated from another place hehe.